### PR TITLE
Use docker/metadata and build-push-action for multi-arch Wechat images

### DIFF
--- a/.github/workflows/wechat.yml
+++ b/.github/workflows/wechat.yml
@@ -4,49 +4,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-image:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Print commit SHA
-        run: |
-          echo "Full commit SHA: $GITHUB_SHA"
-          echo "Short commit SHA: ${GITHUB_SHA::7}"
+      - name: Set Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/wechat
+          tags: |
+            type=sha,format=short
+            type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push amd64 image
-        run: |
-          SHORT_SHA=${GITHUB_SHA::7}
-          docker buildx build \
-            --platform linux/amd64 \
-            --no-cache \
-            -t weiensong/wechat_amd64:$SHORT_SHA \
-            -t weiensong/wechat_amd64:latest \
-            --push \
-            ./wechat
-
-      - name: Build and push arm64 image
-        run: |
-          SHORT_SHA=${GITHUB_SHA::7}
-          docker buildx build \
-            --platform linux/arm64 \
-            --no-cache \
-            --build-arg TARGETARCH=arm64 \
-            -t weiensong/wechat_arm64:$SHORT_SHA \
-            -t weiensong/wechat_arm64:latest \
-            --push \
-            ./wechat
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./wechat
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Motivation
- Modernize the GitHub Actions workflow to use current action versions and centralize image metadata and tagging.
- Replace duplicated manual build steps for each architecture with a single multi-platform build to simplify maintenance and ensure consistent tags/labels.

### Description
- Renamed the job from `build` to `build-image` and updated `actions/checkout` to `@v4`.
- Added `docker/metadata-action@v5` as `Set Metadata` to generate image `tags` and `labels` using `${{ secrets.DOCKERHUB_USERNAME }}`.
- Upgraded support actions to `docker/setup-qemu-action@v3`, `docker/setup-buildx-action@v3`, and `docker/login-action@v3`.
- Replaced two manual `docker buildx build` steps with a single `docker/build-push-action@v6` step that builds and pushes both `linux/amd64` and `linux/arm64` using the metadata outputs for `tags` and `labels`.

### Testing
- No automated workflow runs were executed as part of this change (the workflow file was updated but not dispatched), so CI results are not yet available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deedf28680832a9063631351faafe4)