### PR TITLE
Add GitHub Action to sync Docker Hub repo info and add READMEs for fileserver, gitweb, wechat

### DIFF
--- a/.github/workflows/sync-dockerhub-repo-info.yml
+++ b/.github/workflows/sync-dockerhub-repo-info.yml
@@ -1,0 +1,82 @@
+name: Sync Docker Hub Repository Info
+
+on:
+  workflow_dispatch:
+    inputs:
+      category:
+        description: Optional Docker Hub category slug (applies to all repos)
+        required: false
+        type: string
+
+jobs:
+  sync-repo-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Login to Docker Hub API
+        id: login
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          jwt="$(curl -fsSL -X POST https://hub.docker.com/v2/users/login/ \
+            -H 'Content-Type: application/json' \
+            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" | jq -r '.token')"
+
+          if [ -z "${jwt}" ] || [ "${jwt}" = "null" ]; then
+            echo "Failed to obtain Docker Hub JWT token." >&2
+            exit 1
+          fi
+
+          echo "jwt=${jwt}" >> "$GITHUB_OUTPUT"
+
+      - name: Sync repository descriptions and overviews
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_JWT: ${{ steps.login.outputs.jwt }}
+          CATEGORY: ${{ github.event.inputs.category }}
+        run: |
+          set -euo pipefail
+
+          repos=(fileserver gitweb wechat)
+
+          for repo in "${repos[@]}"; do
+            readme_path="${repo}/README.md"
+            if [ ! -f "${readme_path}" ]; then
+              echo "Missing ${readme_path}" >&2
+              exit 1
+            fi
+
+            description="$(awk 'NF && $0 !~ /^#/ {print; exit}' "${readme_path}")"
+            full_description="$(cat "${readme_path}")"
+
+            payload="$(jq -n \
+              --arg description "${description}" \
+              --arg full_description "${full_description}" \
+              --arg category "${CATEGORY}" \
+              'if $category == "" then
+                {description: $description, full_description: $full_description}
+               else
+                {description: $description, full_description: $full_description, category: $category}
+               end')"
+
+            http_code="$(curl -sS -o /tmp/dockerhub_response.json -w '%{http_code}' \
+              -X PATCH "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/" \
+              -H "Authorization: JWT ${DOCKERHUB_JWT}" \
+              -H 'Content-Type: application/json' \
+              -d "${payload}")"
+
+            if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+              echo "Failed to update ${repo}, HTTP ${http_code}" >&2
+              cat /tmp/dockerhub_response.json >&2
+              exit 1
+            fi
+
+            echo "Updated ${DOCKERHUB_USERNAME}/${repo}"
+          done

--- a/fileserver/README.md
+++ b/fileserver/README.md
@@ -1,0 +1,15 @@
+# fileserver
+
+A lightweight static file server image based on Python, intended for personal and small-team LAN distribution scenarios.
+
+## Highlights
+
+- Simple Python HTTP service startup
+- Minimal image footprint
+- Easy volume mounting for directory sharing
+
+## Usage
+
+```bash
+docker run --rm -p 8000:8000 -v "$PWD:/data" weiensong/fileserver:latest
+```

--- a/gitweb/README.md
+++ b/gitweb/README.md
@@ -1,0 +1,15 @@
+# gitweb
+
+A GitWeb + nginx container image for quickly browsing Git repositories through a web UI.
+
+## Highlights
+
+- GitWeb integrated with nginx/fcgiwrap startup flow
+- Suitable for read-only repository browsing in internal networks
+- Supports multi-architecture image builds
+
+## Usage
+
+```bash
+docker run --rm -p 8080:80 -v /path/to/repos:/var/lib/git weiensong/git:latest
+```

--- a/wechat/README.md
+++ b/wechat/README.md
@@ -1,0 +1,15 @@
+# wechat
+
+A containerized WeChat desktop runtime environment adapted for Linux container workflows.
+
+## Highlights
+
+- Encapsulated startup scripts for easier runtime orchestration
+- Designed for amd64 and arm64 builds
+- Can be combined with X11/VNC related runtime environments
+
+## Usage
+
+```bash
+docker run --rm -it weiensong/wechat:latest
+```


### PR DESCRIPTION
### Motivation

- Provide an automated way to keep Docker Hub repository descriptions and full overviews in sync with in-repo `README.md` files.
- Add basic README documentation for the `fileserver`, `gitweb`, and `wechat` images so meaningful descriptions can be synced.

### Description

- Add a GitHub Actions workflow `sync-dockerhub-repo-info.yml` that supports manual `workflow_dispatch` with an optional `category` input and runs on `ubuntu-latest`.
- The workflow checks out the repo, installs `jq`, logs into Docker Hub via the `/v2/users/login/` endpoint to obtain a JWT, and patches each repository (`fileserver`, `gitweb`, `wechat`) via `PATCH https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/` with `description`, `full_description`, and optional `category` fields.
- The workflow extracts the first non-empty, non-heading line from each `README.md` as the short description and uses the full `README.md` as `full_description`, and it fails the run on missing README or non-2xx HTTP responses.
- Add new `README.md` files for `fileserver`, `gitweb`, and `wechat` containing highlights and a minimal usage example.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0194f130832aa42276b9dd371db6)